### PR TITLE
Add workshop materials and sample code for Django + React Native

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# Django-React-native
+# TaskBuddy Workshop
+
+A 3-day hands-on workshop teaching CSE students how to build a real-world mobile app using Django (backend) and React Native (frontend).
+
+## 📅 Sessions
+- Day 1: Django REST API
+- Day 2: React Native Frontend
+- Day 3: Integration & Deployment
+
+## 🚀 Quick Start
+
+### Backend
+1. `cd backend`
+2. `bash setup.sh`
+3. `python manage.py runserver`
+
+### Frontend
+1. `cd frontend`
+2. `bash setup.sh`
+3. `expo start`
+
+## 📄 Session Materials
+- `backend/day1_backend.md`
+- `frontend/day2_frontend.md`
+- Additional notes in each folder.
+
+## 📝 License
+[MIT](LICENSE)

--- a/backend/day1_backend.md
+++ b/backend/day1_backend.md
@@ -1,0 +1,18 @@
+# Day 1 – Django Backend
+
+## Morning Session
+- Introduction to Django and REST APIs
+- Environment setup (Python, Django, Postman)
+- Project creation
+- Task model and migrations
+- CRUD APIs with Django REST Framework
+- Testing APIs with Postman
+
+## Afternoon Session
+- Token-based authentication
+- Registration and login endpoints
+- Protecting endpoints with permissions
+- API versioning and error handling
+
+## Homework
+Add a `Category` model and link it with `Task` for better organization.

--- a/backend/sample_code/manage.py
+++ b/backend/sample_code/manage.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+import os
+import sys
+
+def main():
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'taskbuddy.settings')
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError as exc:
+        raise ImportError("Couldn't import Django") from exc
+    execute_from_command_line(sys.argv)
+
+if __name__ == '__main__':
+    main()

--- a/backend/sample_code/tasks/models.py
+++ b/backend/sample_code/tasks/models.py
@@ -1,0 +1,11 @@
+from django.db import models
+from django.contrib.auth.models import User
+
+class Task(models.Model):
+    title = models.CharField(max_length=200)
+    description = models.TextField(blank=True)
+    is_completed = models.BooleanField(default=False)
+    owner = models.ForeignKey(User, on_delete=models.CASCADE)
+
+    def __str__(self):
+        return self.title

--- a/backend/sample_code/tasks/serializers.py
+++ b/backend/sample_code/tasks/serializers.py
@@ -1,0 +1,7 @@
+from rest_framework import serializers
+from .models import Task
+
+class TaskSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Task
+        fields = ['id', 'title', 'description', 'is_completed']

--- a/backend/sample_code/tasks/urls.py
+++ b/backend/sample_code/tasks/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+from .views import TaskListCreate, TaskDetail
+
+urlpatterns = [
+    path('tasks/', TaskListCreate.as_view(), name='task-list'),
+    path('tasks/<int:pk>/', TaskDetail.as_view(), name='task-detail'),
+]

--- a/backend/sample_code/tasks/views.py
+++ b/backend/sample_code/tasks/views.py
@@ -1,0 +1,13 @@
+from rest_framework import generics, permissions
+from .models import Task
+from .serializers import TaskSerializer
+
+class TaskListCreate(generics.ListCreateAPIView):
+    queryset = Task.objects.all()
+    serializer_class = TaskSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+class TaskDetail(generics.RetrieveUpdateDestroyAPIView):
+    queryset = Task.objects.all()
+    serializer_class = TaskSerializer
+    permission_classes = [permissions.IsAuthenticated]

--- a/backend/setup.sh
+++ b/backend/setup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+python3 -m venv env
+source env/bin/activate
+pip install django djangorestframework djangorestframework-simplejwt
+django-admin startproject taskbuddy .
+python manage.py startapp tasks
+python manage.py migrate
+python manage.py createsuperuser

--- a/frontend/day2_frontend.md
+++ b/frontend/day2_frontend.md
@@ -1,0 +1,15 @@
+# Day 2 – React Native Frontend
+
+## Morning Session
+- Introduction to React Native and Expo
+- Project structure and components
+- Task list and Add Task screens
+- React Navigation setup
+- API integration with Axios
+- Display data from Django backend
+
+## Afternoon Session
+- Forms for creating and editing tasks
+- Using `useState` and `useEffect`
+- Feedback with toasts, loading indicators, and error messages
+- Optional: Date/time picker and AsyncStorage

--- a/frontend/sample_code/App.js
+++ b/frontend/sample_code/App.js
@@ -1,0 +1,23 @@
+import React, { useEffect, useState } from 'react';
+import { FlatList, View, Text } from 'react-native';
+import axios from 'axios';
+
+export default function App() {
+  const [tasks, setTasks] = useState([]);
+
+  useEffect(() => {
+    axios.get('http://<backend-url>/api/tasks/')
+      .then(res => setTasks(res.data))
+      .catch(console.error);
+  }, []);
+
+  return (
+    <View>
+      <FlatList
+        data={tasks}
+        keyExtractor={item => item.id.toString()}
+        renderItem={({ item }) => <Text>{item.title}</Text>}
+      />
+    </View>
+  );
+}

--- a/frontend/setup.sh
+++ b/frontend/setup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+npm install -g expo-cli
+expo init taskbuddy-mobile
+cd taskbuddy-mobile
+npm install axios @react-navigation/native @react-navigation/stack
+npm install react-native-gesture-handler react-native-reanimated react-native-screens react-native-safe-area-context @react-native-community/masked-view

--- a/lecturer_notes.md
+++ b/lecturer_notes.md
@@ -1,0 +1,19 @@
+# Lecturer Notes
+
+## Day 1 – Backend
+- Introduce MVC architecture and REST fundamentals.
+- Demonstrate migrations and API endpoints live.
+- Prompt students to test every change via Postman.
+- Highlight common pitfalls like missing migrations and auth headers.
+- Encourage small commits after each milestone.
+
+## Day 2 – Frontend
+- Discuss React component lifecycle with hooks.
+- Demonstrate network request flow (loading → success/error).
+- Stress meaningful UI feedback (spinners, toasts).
+- Offer mini challenges such as task filtering.
+
+## Day 3 – Integration & Deployment
+- Show deployment to Render/Heroku step-by-step.
+- Explain CORS and mobile API permissions.
+- Encourage debugging strategies and final project presentations.


### PR DESCRIPTION
## Summary
- add backend and frontend setup scripts and guides
- include sample Django REST API and React Native app code
- provide lecturer notes for 3-day workshop

## Testing
- `python -m py_compile backend/sample_code/manage.py backend/sample_code/tasks/models.py backend/sample_code/tasks/serializers.py backend/sample_code/tasks/views.py backend/sample_code/tasks/urls.py`
- `bash -n backend/setup.sh`
- `bash -n frontend/setup.sh`
- `node --check frontend/sample_code/App.js`


------
https://chatgpt.com/codex/tasks/task_e_68bf7e154de08322a9583f89a8cdc342